### PR TITLE
Haddoc fixes

### DIFF
--- a/!DLGenRelease/.gitignore
+++ b/!DLGenRelease/.gitignore
@@ -1,2 +1,4 @@
 /haddoc,ff8
 /haddoctosh,ff8
+/haddoc
+/haddoctosh

--- a/!DLGenRelease/Sources/haddoc/input.c
+++ b/!DLGenRelease/Sources/haddoc/input.c
@@ -592,26 +592,26 @@ int read_macro(object_info *object, FILE *fptr)
 	compress_macro(object->definition);
 
 	/* Extract name information and similar here */
-	no_results = pcre_exec(regexes_too[re_names_MACROFN], NULL,
+	no_results = pcre_exec(regexes_too[re_names_MACRO], NULL,
 						   object->definition, strlen(object->definition),
 						   0, 0, ovector, OVECTOR_SIZE);
 
 	if (ovector[2] != -1 && ovector[3] != -1)
 	{
-		object->type = obj_MACROFN;
+		object->type = obj_MACRO;
 
 	    add_name_n(object, object->definition + ovector[2],
 	    		   ovector[3] - ovector[2]);
 	}
 	else
 	{
-		no_results = pcre_exec(regexes_too[re_names_MACRO], NULL,
+		no_results = pcre_exec(regexes_too[re_names_MACROFN], NULL,
 							   object->definition, strlen(object->definition),
 							   0, 0, ovector, OVECTOR_SIZE);
 
 		if (ovector[2] != -1 && ovector[3] != -1)
 		{
-			object->type = obj_MACRO;
+			object->type = obj_MACROFN;
 
 	        add_name_n(object, object->definition + ovector[2],
 	        		   ovector[3] - ovector[2]);

--- a/!DLGenRelease/Sources/haddoc/regexps.c
+++ b/!DLGenRelease/Sources/haddoc/regexps.c
@@ -39,7 +39,7 @@ const char *patterns_too[NO_PATTERNS_TOO] =
 	"^\\s*((?:struct|enum|union) [A-Za-z_][A-Za-z0-9_]*)",   /* struct-like */
 	"^\\s*typedef\\s+((?:struct|enum|union)( [A-Za-z_][A-Za-z0-9_]*)?) ?{.*}\\s*(.*);",
 	"^\\s*#\\s*define\\s*([A-Za-z_][A-Za-z0-9_]*)\\(",
-	"^\\s*#\\s*define\\s*([A-Za-z_][A-Za-z0-9_]*)",
+	"^\\s*#\\s*define\\s*([A-Za-z_][A-Za-z0-9_]*)\\s*",
 
 	"^.*?(\\(\\s*\\*.*?)?([A-Za-z_][A-Za-z0-9_]*)(?:\\s*|\\))*\\($",
 

--- a/!DLGenRelease/Sources/haddoctosh/Makefile
+++ b/!DLGenRelease/Sources/haddoctosh/Makefile
@@ -7,7 +7,7 @@
 default: riscos
 
 # Set the default output executable
-TARGET = ^.^.haddoctosh
+TARGET = ../../haddoctosh
 
 # Warning options
 WARNINGS = \

--- a/!DLGenRelease/Sources/haddoctosh/haddoctosh.c
+++ b/!DLGenRelease/Sources/haddoctosh/haddoctosh.c
@@ -9,7 +9,7 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "libxml:parser.h"
+#include "libxml/parser.h"
 
 #include "hparser.h"
 #include "haddoctosh.h"

--- a/!DLGenRelease/Sources/haddoctosh/output.c
+++ b/!DLGenRelease/Sources/haddoctosh/output.c
@@ -13,11 +13,11 @@
 
 #include <assert.h>
 
-#include "libxml:parser.h"
+#include "libxml/parser.h"
 
 #include "haddoctosh.h"
 #include "output.h"
-#include "parser.h"
+/* #include "parser.h" */
 
 #ifdef RISCOS
   #include "kernel.h"

--- a/!DLGenRelease/Sources/haddoctosh/parser.c
+++ b/!DLGenRelease/Sources/haddoctosh/parser.c
@@ -34,12 +34,12 @@
 #include <assert.h>
 
 
-#include "libxml:parser.h"
-#include "libxml:parserInternals.h"
+#include "libxml/parser.h"
+#include "libxml/parserInternals.h"
 #ifdef RISCOS
 //#include "libxml:riscos.h"
 #endif
-#include "libxml:tree.h"
+#include "libxml/tree.h"
 
 
 #include "haddoctosh.h"

--- a/!DeskLib/include/Clear.h
+++ b/!DeskLib/include/Clear.h
@@ -40,8 +40,8 @@ typedef struct
   const char   *creator;
   unsigned      creatorversion;
 
-  unsigned      width,
-                height;
+  unsigned      width;
+  unsigned      height;
   unsigned      bpp;
 
   palette_entry *palette;

--- a/!DeskLib/include/Font.h
+++ b/!DeskLib/include/Font.h
@@ -52,8 +52,10 @@ typedef unsigned char font_handle;
 typedef struct
 {
   char name[128];
-  unsigned int xsize, ysize;
-  unsigned int xres, yres;
+  unsigned int xsize;
+  unsigned int ysize;
+  unsigned int xres;
+  unsigned int yres;
   unsigned int age;
   unsigned int usage;
 } font_defn;
@@ -71,7 +73,10 @@ typedef struct
 
 typedef struct
 {
-    int minx, miny, maxx, maxy;
+    int minx;
+    int miny;
+    int maxx;
+    int maxy;
 } font_info;
 /*
   This is used to give a bounding box for a font or a character in a
@@ -101,7 +106,8 @@ typedef struct
 
 typedef struct
 {
-  int background, foreground;
+  int background;
+  int foreground;
 } font_colours;
 /*
   The logical colours of the font.

--- a/!DeskLib/include/Wimp.h
+++ b/!DeskLib/include/Wimp.h
@@ -51,7 +51,8 @@ extern "C" {
 
 typedef struct
 {
-  int x, y;
+  int x
+  int y;
 } wimp_point;
 /*
   A C struct which corresponds with how the RISC OS Window Manager usually
@@ -593,7 +594,16 @@ typedef struct
 {
   window_openblock openblock;
   window_flags     flags;
-} window_state, window_openblocknest;
+} window_state;
+/*
+  This holds all the information about the current state of a window.
+
+  When used with Wimp_OpenWindowNest, the supplied flags will update
+  the window if 'updateflags' is set in the supplied nested flags
+*/
+
+
+typedef window_state window_openblocknest;
 /*
   This holds all the information about the current state of a window.
 
@@ -900,7 +910,10 @@ typedef struct
 typedef struct menu_block
 {
   char     title [wimp_MAXNAME];
-  char     titlefore, titleback, workfore, workback;
+  char     titlefore;
+  char     titleback;
+  char     workfore;
+  char     workback;
   unsigned int width;
   unsigned int height;
   unsigned int gap;
@@ -1287,7 +1300,8 @@ typedef struct
 {
   window_handle window;
   unsigned int  internal_handle;
-  int           x, y;
+  int           x;
+  int           y;
   int           dummy    : 2;
   int           senddata : 1;
   int           filetypes[1];


### PR DESCRIPTION
With this PR, generating HTML and StrongHelp manuals under Linux now works correctly. In the long term, it may be more practical to switch to Doxygen instead, since haddoc doesn't seem to be maintained anymore and is quite picky about how code is structured.